### PR TITLE
Question/Answer pairs removed from array after a correct answer, and add...

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -50,10 +50,10 @@ function CheckWord() {
 
     // Remove that question and go to another question.
     // Also, reset the text field to be blank. --Korey
-    var completed = secretWords.indexOf(currentSecretWord);
-    if (completed !== -1) {
-      secretWords.splice(completed, 1);
-    }
+    var correctIndex = secretWords.indexOf(currentSecretWord);
+    var correctAnswer = secretWords.splice(correctIndex, 1);
+    correctWords.push(correctAnswer);
+
     document.getElementById('txtGuess').value = "";
     OnLoad();
 
@@ -142,6 +142,18 @@ function restartGame() {
   resultDiv.style.display = 'none';
   submitButton.disabled = false;
   restartButton.style.display = 'none';
+  
+  resetSecretWord(secretWords, correctWords);
+  
   resetPlayer();
   OnLoad();
 }
+
+var resetSecretWord = function(mainArray, tempArray) {
+  for (var i = 0; i < tempArray.length; i++) {
+    mainArray.push(tempArray[i][0]);    
+  }
+  tempArray.length = 0;
+}
+
+

--- a/javascript/secretwords.js
+++ b/javascript/secretwords.js
@@ -63,3 +63,5 @@ var secretWords = [
     word: "wisconsin",
     hint: "Badgers and yellow cheese (sometimes as hats)."
 }];
+
+var correctWords = [];


### PR DESCRIPTION
...ed back into array when restarting game.

I had it splice out the q/a pairs when a user gets an answer correct, putting that object in a new array. Then, when the game is reset, the correct answers in the new array will be added back into the original q/a list (secretWords). 

Originally, the q/a pairs were removed, but not added back in, so the user might eventually run out of questions when restarting the game multiple times.
